### PR TITLE
Initialize tracing and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,8 +706,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -709,8 +727,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -820,12 +844,14 @@ dependencies = [
  "clap",
  "color-eyre",
  "eyre",
+ "once_cell",
  "regex",
  "serde",
  "serde_yaml",
  "strsim",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "url",
  "xdg",
@@ -1020,10 +1046,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.9.34"
 strsim = "0.11.1"
 tokio = { version = "1.45.1", features = ["rt-multi-thread", "macros"] }
-tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
+tracing = { version = "0.1.41", features = ["release_max_level_debug"] }
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-log = "0.2.0"
+once_cell = "1.19.0"
 url = "2.5.4"
 xdg = "3.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,1 +1,9 @@
-fn main() {}
+use color_eyre::eyre::Result;
+use tracing::instrument;
+
+#[instrument(level = "trace")]
+fn main() -> Result<()> {
+    shortcut_catapult::init()?;
+    tracing::trace!("main executed");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add tracing and color-eyre initialization helpers
- wire up main to use new initialization and produce a trace log
- depend on tracing-log and once_cell
- compile release builds without trace-level logging
- test initialization function

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `CATAPULT_LOG=trace cargo run 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_684ee260b2f0832da217478690f70841