### PR TITLE
Add CLI parsing with subcommands

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,0 +1,10 @@
+use color_eyre::eyre::Result;
+use tracing::{info, instrument};
+
+use crate::cli::ApplyArgs;
+
+#[instrument(level = "debug", skip(args))]
+pub fn run(args: ApplyArgs) -> Result<()> {
+    info!(url = ?args.url, "apply stub");
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,51 @@
+use clap::{Args, Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct Cli {
+    /// Enable INFO logging
+    #[arg(long, global = true)]
+    pub info: bool,
+    /// Enable DEBUG logging
+    #[arg(long, global = true)]
+    pub debug: bool,
+    /// Path to config file
+    #[arg(long, value_name = "FILE", global = true)]
+    pub config: Option<PathBuf>,
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+impl Cli {
+    pub fn log_level(&self) -> Option<tracing::Level> {
+        if self.debug {
+            Some(tracing::Level::DEBUG)
+        } else if self.info {
+            Some(tracing::Level::INFO)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Run the HTTP daemon
+    Daemon(DaemonArgs),
+    /// Apply the config to a single URL
+    Apply(ApplyArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct DaemonArgs {
+    /// Port to listen on
+    #[arg(long, default_value = "8081")]
+    pub port: u16,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ApplyArgs {
+    /// URL to process or '-' for stdin
+    pub url: Option<String>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,15 @@
+use std::path::PathBuf;
+
+use color_eyre::eyre::Result;
+
+/// Determine the config file path.
+pub fn config_path(cli: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(p) = cli {
+        return Ok(p);
+    }
+    let xdg = xdg::BaseDirectories::with_prefix("shortcut-catapult");
+    let home = xdg
+        .get_config_home()
+        .ok_or_else(|| color_eyre::eyre::eyre!("missing home directory"))?;
+    Ok(home.join("config.yml"))
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,10 @@
+use color_eyre::eyre::Result;
+use tracing::{info, instrument};
+
+use crate::cli::DaemonArgs;
+
+#[instrument(level = "debug", skip(args))]
+pub fn run(args: DaemonArgs) -> Result<()> {
+    info!(port = args.port, "daemon stub");
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 use color_eyre::eyre::Result;
 use tracing_subscriber::{EnvFilter, prelude::*};
 
+pub mod apply;
+pub mod cli;
+pub mod config;
+pub mod daemon;
+
 /// Initialize error handling and tracing.
 ///
 /// The log level can be configured via the `CATAPULT_LOG` environment variable.
@@ -9,12 +14,16 @@ use once_cell::sync::OnceCell;
 
 static INIT: OnceCell<()> = OnceCell::new();
 
-pub fn init() -> Result<()> {
+pub fn init(level: Option<tracing::Level>) -> Result<()> {
     INIT.get_or_try_init(|| {
         color_eyre::install()?;
         tracing_log::LogTracer::init().ok();
-        let filter =
-            EnvFilter::try_from_env("CATAPULT_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
+        let filter = match level {
+            Some(level) => EnvFilter::new(level.as_str()),
+            None => {
+                EnvFilter::try_from_env("CATAPULT_LOG").unwrap_or_else(|_| EnvFilter::new("warn"))
+            }
+        };
         tracing_subscriber::registry()
             .with(filter)
             .with(tracing_subscriber::fmt::layer())
@@ -31,6 +40,6 @@ mod tests {
 
     #[test]
     fn init_ok() {
-        init().expect("init should not error");
+        init(None).expect("init should not error");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,23 @@
+use clap::Parser;
 use color_eyre::eyre::Result;
 use tracing::instrument;
 
+use shortcut_catapult::{
+    apply,
+    cli::{Cli, Commands},
+    config, daemon,
+};
+
 #[instrument(level = "trace")]
 fn main() -> Result<()> {
-    shortcut_catapult::init()?;
-    tracing::trace!("main executed");
+    let cli = Cli::parse();
+    let level = cli.log_level();
+    shortcut_catapult::init(level)?;
+    let config_path = config::config_path(cli.config.clone())?;
+    tracing::debug!(?config_path, "using config path");
+    match cli.command {
+        Commands::Daemon(args) => daemon::run(args)?,
+        Commands::Apply(args) => apply::run(args)?,
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add Clap-driven CLI parser
- add stubs for `daemon` and `apply` subcommands
- support `--info` and `--debug` flags
- compute config file path via `xdg`
- initialize tracing after CLI parsing

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test --quiet`
- `cargo clippy -- -D warnings`
- `RUST_BACKTRACE=1 ./target/debug/shortcut-catapult --debug apply https://example.com`
- `./target/debug/shortcut-catapult --info daemon --port 9999`
- `./target/debug/shortcut-catapult apply https://example.com`


------
https://chatgpt.com/codex/tasks/task_e_684eeb0964b0832db15ac4e69f7c64d1