### PR TITLE
Add matcher trait and basic implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod apply;
 pub mod cli;
 pub mod config;
 pub mod daemon;
+pub mod matching;
 
 /// Initialize error handling and tracing.
 ///

--- a/src/matching/exact.rs
+++ b/src/matching/exact.rs
@@ -1,0 +1,52 @@
+use eyre::Result;
+use tracing::instrument;
+
+use super::Matcher;
+use crate::config::ExactMatcherConfig;
+
+impl Matcher for ExactMatcherConfig {
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        tracing::info!(matcher = ?self, input, "running exact matcher");
+        let mut candidate = input;
+        if self.trim {
+            candidate = candidate.trim();
+        }
+        let matches = if self.case_sensitive {
+            candidate == self.exact
+        } else {
+            candidate.eq_ignore_ascii_case(&self.exact)
+        };
+        if matches {
+            if let Some(url) = &self.url {
+                let redirect = url.replace("$1", candidate);
+                tracing::info!(%redirect, "exact matcher produced redirect");
+                return Ok(Some(redirect));
+            }
+            if let Some(matcher) = &self.matcher {
+                tracing::info!("exact matcher delegating to sub matcher");
+                return matcher.apply(candidate);
+            }
+        }
+        tracing::info!("exact matcher did not match");
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn match_redirect() {
+        let cfg = ExactMatcherConfig {
+            exact: "Hello".into(),
+            case_sensitive: false,
+            trim: true,
+            url: Some("https://example.com?q=$1".into()),
+            matcher: None,
+        };
+        let result = cfg.apply("Hello").unwrap();
+        assert_eq!(result.unwrap(), "https://example.com?q=Hello");
+    }
+}

--- a/src/matching/fuzzy.rs
+++ b/src/matching/fuzzy.rs
@@ -1,0 +1,12 @@
+use eyre::Result;
+use tracing::instrument;
+
+use super::Matcher;
+use crate::config::FuzzyMatcherConfig;
+
+impl Matcher for FuzzyMatcherConfig {
+    #[instrument(level = "info", skip(self, _input))]
+    fn apply(&self, _input: &str) -> Result<Option<String>> {
+        unimplemented!("fuzzy matcher not implemented yet");
+    }
+}

--- a/src/matching/list.rs
+++ b/src/matching/list.rs
@@ -1,0 +1,48 @@
+use eyre::Result;
+use tracing::instrument;
+
+use super::Matcher;
+use crate::config::MatcherConfig;
+
+impl Matcher for Vec<MatcherConfig> {
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        tracing::info!(?input, "running list matcher");
+        for matcher in self {
+            if let Some(result) = matcher.apply(input)? {
+                tracing::info!("list matcher got match");
+                return Ok(Some(result));
+            }
+        }
+        tracing::info!("list matcher no match");
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::ExactMatcherConfig;
+    use crate::config::MatcherConfig;
+    use crate::matching::Matcher;
+
+    #[test]
+    fn picks_first_match() {
+        let m1 = MatcherConfig::Exact(ExactMatcherConfig {
+            exact: "One".into(),
+            case_sensitive: false,
+            trim: true,
+            url: Some("https://one.example".into()),
+            matcher: None,
+        });
+        let m2 = MatcherConfig::Exact(ExactMatcherConfig {
+            exact: "Two".into(),
+            case_sensitive: false,
+            trim: true,
+            url: Some("https://two.example".into()),
+            matcher: None,
+        });
+        let list = vec![m1, m2];
+        let result = list.apply("Two").unwrap();
+        assert_eq!(result.unwrap(), "https://two.example");
+    }
+}

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -1,0 +1,38 @@
+use eyre::Result;
+
+pub trait Matcher {
+    /// Applies this matcher to the provided `input` URL.
+    ///
+    /// Returns `Ok(Some(url))` if the matcher accepts the input and wants to
+    /// redirect to `url`. Returns `Ok(None)` if the matcher does not match.
+    fn apply(&self, input: &str) -> Result<Option<String>>;
+}
+
+mod exact;
+mod fuzzy;
+mod list;
+mod prefix;
+mod regex;
+
+use crate::config::MatcherConfig;
+use tracing::instrument;
+
+impl Matcher for MatcherConfig {
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        match self {
+            MatcherConfig::Exact(cfg) => cfg.apply(input),
+            MatcherConfig::Prefix(cfg) => cfg.apply(input),
+            MatcherConfig::Fuzzy(cfg) => cfg.apply(input),
+            MatcherConfig::Regex(cfg) => cfg.apply(input),
+            MatcherConfig::List(list) => list.apply(input),
+        }
+    }
+}
+
+impl Matcher for Box<MatcherConfig> {
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        self.as_ref().apply(input)
+    }
+}

--- a/src/matching/prefix.rs
+++ b/src/matching/prefix.rs
@@ -1,0 +1,12 @@
+use eyre::Result;
+use tracing::instrument;
+
+use super::Matcher;
+use crate::config::PrefixMatcherConfig;
+
+impl Matcher for PrefixMatcherConfig {
+    #[instrument(level = "info", skip(self, _input))]
+    fn apply(&self, _input: &str) -> Result<Option<String>> {
+        unimplemented!("prefix matcher not implemented yet");
+    }
+}

--- a/src/matching/regex.rs
+++ b/src/matching/regex.rs
@@ -1,0 +1,12 @@
+use eyre::Result;
+use tracing::instrument;
+
+use super::Matcher;
+use crate::config::RegexMatcherConfig;
+
+impl Matcher for RegexMatcherConfig {
+    #[instrument(level = "info", skip(self, _input))]
+    fn apply(&self, _input: &str) -> Result<Option<String>> {
+        unimplemented!("regex matcher not implemented yet");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `matching` module defining `Matcher` trait
- add stub matchers for prefix, fuzzy and regex
- implement exact and list matcher logic with tracing
- expose `matching` module in lib
- add unit tests for exact and list matchers

## Testing
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684eefefdb20832da30ab66591532fd4