### PR TITLE
Implement regex matcher

### DIFF
--- a/src/matching/regex.rs
+++ b/src/matching/regex.rs
@@ -1,12 +1,56 @@
 use eyre::Result;
+use regex::RegexBuilder;
 use tracing::instrument;
 
 use super::Matcher;
 use crate::config::RegexMatcherConfig;
 
 impl Matcher for RegexMatcherConfig {
-    #[instrument(level = "info", skip(self, _input))]
-    fn apply(&self, _input: &str) -> Result<Option<String>> {
-        unimplemented!("regex matcher not implemented yet");
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        tracing::info!(matcher = ?self, input, "running regex matcher");
+
+        let regex = RegexBuilder::new(&self.regex)
+            .case_insensitive(!self.case_sensitive)
+            .build()?;
+
+        let Some(caps) = regex.captures(input) else {
+            tracing::info!("regex matcher did not match");
+            return Ok(None);
+        };
+
+        // Determine the value forwarded to the sub matcher or used for $1 placeholder
+        let matched = caps.get(0).map(|m| m.as_str()).unwrap_or("");
+        let candidate = if let Some(template) = &self.match_with {
+            substitute_template(template, &caps)
+        } else {
+            matched.to_string()
+        };
+
+        if let Some(url) = &self.url {
+            let mut redirect = url.clone();
+            redirect = substitute_template(&redirect, &caps);
+            tracing::info!(%redirect, "regex matcher produced redirect");
+            return Ok(Some(redirect));
+        }
+
+        if let Some(matcher) = &self.matcher {
+            tracing::info!("regex matcher delegating to sub matcher");
+            return matcher.apply(&candidate);
+        }
+
+        tracing::info!("regex matcher did not match");
+        Ok(None)
     }
+}
+
+fn substitute_template(template: &str, caps: &regex::Captures) -> String {
+    let mut result = template.to_string();
+    for i in 0..caps.len() {
+        if let Some(m) = caps.get(i) {
+            let placeholder = format!("${}", i);
+            result = result.replace(&placeholder, m.as_str());
+        }
+    }
+    result
 }

--- a/tests/regex.rs
+++ b/tests/regex.rs
@@ -1,0 +1,57 @@
+use assert_cmd::Command;
+use assert_fs::fixture::NamedTempFile;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+const REGEX_CONFIG: &str = "match:\n  regex: (\\w+)\\.txt$\n  url: https://file.drive/$1.txt\n";
+const SUBMATCH_CONFIG: &str = "match:\n  regex: ^animals/(\\w{1,3})\\w*\\.(\\w+)\n  match-with: $1.$2\n  match:\n    exact: Bea.pdf\n    url: https://animals.example/$1\n";
+
+fn run_apply(config: &str, arg: Option<&str>, stdin: Option<&str>) -> assert_cmd::assert::Assert {
+    let file = NamedTempFile::new("config.yml").expect("temp file");
+    file.write_str(config).expect("write config");
+    let mut cmd = Command::cargo_bin("shortcut-catapult").expect("binary exists");
+    cmd.arg("--config").arg(file.path()).arg("apply");
+    if let Some(a) = arg {
+        cmd.arg(a);
+    }
+    if let Some(input) = stdin {
+        cmd.write_stdin(input);
+    }
+    cmd.assert()
+}
+
+#[test]
+fn command_line_match_outputs_redirect() {
+    run_apply(REGEX_CONFIG, Some("Bear.txt"), None)
+        .success()
+        .stdout(predicate::eq("https://file.drive/Bear.txt"));
+}
+
+#[test]
+fn stdin_dash_match_outputs_redirect() {
+    run_apply(REGEX_CONFIG, Some("-"), Some("Bear.txt"))
+        .success()
+        .stdout(predicate::eq("https://file.drive/Bear.txt"));
+}
+
+#[test]
+fn stdin_implicit_match_outputs_redirect() {
+    run_apply(REGEX_CONFIG, None, Some("Bear.txt"))
+        .success()
+        .stdout(predicate::eq("https://file.drive/Bear.txt"));
+}
+
+#[test]
+fn no_match_exit_code_two() {
+    run_apply(REGEX_CONFIG, Some("World"), None)
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn list_picks_first_match() {
+    run_apply(SUBMATCH_CONFIG, Some("animals/Bears.pdf"), None)
+        .success()
+        .stdout(predicate::eq("https://animals.example/Bea.pdf"));
+}


### PR DESCRIPTION
## Summary
- implement RegexMatcherConfig::apply
- add helper function to substitute placeholders from regex captures
- test the regex matcher through `shortcut-catapult apply`

## Testing
- `cargo test --quiet`
- `cargo clippy -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_684efb3d7e2c832d89ea9e451ace8542