### PR TITLE
Implement prefix matcher

### DIFF
--- a/src/matching/prefix.rs
+++ b/src/matching/prefix.rs
@@ -5,8 +5,37 @@ use super::Matcher;
 use crate::config::PrefixMatcherConfig;
 
 impl Matcher for PrefixMatcherConfig {
-    #[instrument(level = "info", skip(self, _input))]
-    fn apply(&self, _input: &str) -> Result<Option<String>> {
-        unimplemented!("prefix matcher not implemented yet");
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        tracing::info!(matcher = ?self, input, "running prefix matcher");
+
+        if input.len() < self.prefix.len() {
+            tracing::info!("prefix matcher did not match");
+            return Ok(None);
+        }
+
+        let candidate_prefix = &input[..self.prefix.len()];
+        let matches = if self.case_sensitive {
+            candidate_prefix == self.prefix
+        } else {
+            candidate_prefix.eq_ignore_ascii_case(&self.prefix)
+        };
+
+        if matches {
+            let remainder = &input[self.prefix.len()..];
+            if let Some(url) = &self.url {
+                let redirect = url.replace("$1", candidate_prefix).replace("$2", remainder);
+                tracing::info!(%redirect, "prefix matcher produced redirect");
+                return Ok(Some(redirect));
+            }
+
+            if let Some(matcher) = &self.matcher {
+                tracing::info!("prefix matcher delegating to sub matcher");
+                return matcher.apply(remainder);
+            }
+        }
+
+        tracing::info!("prefix matcher did not match");
+        Ok(None)
     }
 }

--- a/tests/prefix.rs
+++ b/tests/prefix.rs
@@ -1,0 +1,58 @@
+use assert_cmd::Command;
+use assert_fs::fixture::NamedTempFile;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+const PREFIX_CONFIG: &str = "match:\n  prefix: Arm\n  url: https://example.com?q=$1+$2\n";
+const SUBMATCH_CONFIG: &str =
+    "match:\n  prefix: animals/\n  match:\n    exact: bear\n    url: https://bears.org\n";
+
+fn run_apply(config: &str, arg: Option<&str>, stdin: Option<&str>) -> assert_cmd::assert::Assert {
+    let file = NamedTempFile::new("config.yml").expect("temp file");
+    file.write_str(config).expect("write config");
+    let mut cmd = Command::cargo_bin("shortcut-catapult").expect("binary exists");
+    cmd.arg("--config").arg(file.path()).arg("apply");
+    if let Some(a) = arg {
+        cmd.arg(a);
+    }
+    if let Some(input) = stdin {
+        cmd.write_stdin(input);
+    }
+    cmd.assert()
+}
+
+#[test]
+fn command_line_match_outputs_redirect() {
+    run_apply(PREFIX_CONFIG, Some("Armadillo"), None)
+        .success()
+        .stdout(predicate::eq("https://example.com?q=Arm+adillo"));
+}
+
+#[test]
+fn stdin_dash_match_outputs_redirect() {
+    run_apply(PREFIX_CONFIG, Some("-"), Some("Armadillo"))
+        .success()
+        .stdout(predicate::eq("https://example.com?q=Arm+adillo"));
+}
+
+#[test]
+fn stdin_implicit_match_outputs_redirect() {
+    run_apply(PREFIX_CONFIG, None, Some("Armadillo"))
+        .success()
+        .stdout(predicate::eq("https://example.com?q=Arm+adillo"));
+}
+
+#[test]
+fn no_match_exit_code_two() {
+    run_apply(PREFIX_CONFIG, Some("Hello"), None)
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn prefix_delegates_to_submatcher() {
+    run_apply(SUBMATCH_CONFIG, Some("animals/bear"), None)
+        .success()
+        .stdout(predicate::eq("https://bears.org"));
+}


### PR DESCRIPTION
## Summary
- implement prefix matcher
- add integration tests for prefix matcher

## Testing
- `cargo check`
- `cargo test --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684efb5c5dc0832da44f749a897a3fa4