### PR TITLE
Implement fuzzy matcher

### DIFF
--- a/src/matching/fuzzy.rs
+++ b/src/matching/fuzzy.rs
@@ -5,8 +5,24 @@ use super::Matcher;
 use crate::config::FuzzyMatcherConfig;
 
 impl Matcher for FuzzyMatcherConfig {
-    #[instrument(level = "info", skip(self, _input))]
-    fn apply(&self, _input: &str) -> Result<Option<String>> {
-        unimplemented!("fuzzy matcher not implemented yet");
+    #[instrument(level = "info", skip(self, input))]
+    fn apply(&self, input: &str) -> Result<Option<String>> {
+        tracing::info!(matcher = ?self, input, "running fuzzy matcher");
+
+        let distance = strsim::levenshtein(input, &self.fuzzy);
+        if distance as u32 <= self.tolerance {
+            if let Some(url) = &self.url {
+                let redirect = url.replace("$1", input);
+                tracing::info!(%redirect, "fuzzy matcher produced redirect");
+                return Ok(Some(redirect));
+            }
+            if let Some(matcher) = &self.matcher {
+                tracing::info!("fuzzy matcher delegating to sub matcher");
+                return matcher.apply(input);
+            }
+        }
+
+        tracing::info!("fuzzy matcher did not match");
+        Ok(None)
     }
 }

--- a/tests/fuzzy.rs
+++ b/tests/fuzzy.rs
@@ -1,0 +1,44 @@
+use assert_cmd::Command;
+use assert_fs::fixture::NamedTempFile;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+const FUZZY_CONFIG: &str = "match:\n  fuzzy: Elephant\n  url: https://heavy.animal?q=$1\n";
+
+fn run_apply(config: &str, arg: Option<&str>, stdin: Option<&str>) -> assert_cmd::assert::Assert {
+    let file = NamedTempFile::new("config.yml").expect("temp file");
+    file.write_str(config).expect("write config");
+    let mut cmd = Command::cargo_bin("shortcut-catapult").expect("binary exists");
+    cmd.arg("--config").arg(file.path()).arg("apply");
+    if let Some(a) = arg {
+        cmd.arg(a);
+    }
+    if let Some(input) = stdin {
+        cmd.write_stdin(input);
+    }
+    cmd.assert()
+}
+
+#[test]
+fn within_tolerance_outputs_redirect() {
+    run_apply(FUZZY_CONFIG, Some("Elefant"), None)
+        .success()
+        .stdout(predicate::eq("https://heavy.animal?q=Elefant"));
+}
+
+#[test]
+fn no_match_exit_code_two() {
+    run_apply(FUZZY_CONFIG, Some("Cat"), None)
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn respect_tolerance_setting() {
+    let cfg = "match:\n  fuzzy: Elephant\n  tolerance: 1\n  url: https://heavy.animal\n";
+    run_apply(cfg, Some("Elefant"), None)
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty());
+}


### PR DESCRIPTION
## Summary
- implement the fuzzy matcher
- add integration tests for fuzzy matching

## Testing
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_684efbb2e97c832da0b847620c12e7dc