### PR TITLE
Improve config missing error context

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -20,7 +20,7 @@ pub fn run(args: ApplyArgs, config_path: PathBuf) -> Result<()> {
     };
     input = input.trim_end_matches(&['\n', '\r'][..]).to_string();
 
-    let cfg_str = std::fs::read_to_string(&config_path)?;
+    let cfg_str = crate::config::read(&config_path)?;
     let cfg: Config = Config::parse(&cfg_str)?;
 
     match cfg.matcher.apply(&input)? {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Context, Result};
 use serde::Deserialize;
 use std::path::PathBuf;
 
@@ -110,6 +110,28 @@ pub fn config_path(cli: Option<PathBuf>) -> Result<PathBuf> {
         .get_config_home()
         .ok_or_else(|| color_eyre::eyre::eyre!("missing home directory"))?;
     Ok(home.join("config.yml"))
+}
+
+/// Read the configuration file synchronously.
+pub fn read(config_path: &std::path::Path) -> Result<String> {
+    std::fs::read_to_string(config_path).wrap_err_with(|| {
+        format!(
+            "failed to read configuration file at {}",
+            config_path.display()
+        )
+    })
+}
+
+/// Read the configuration file asynchronously.
+pub async fn read_async(config_path: &std::path::Path) -> Result<String> {
+    tokio::fs::read_to_string(config_path)
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to read configuration file at {}",
+                config_path.display()
+            )
+        })
 }
 
 #[cfg(test)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,7 +22,7 @@ async fn handler(State(state): State<AppState>, Path(path): Path<String>) -> Res
     let input = path.trim_start_matches('/');
 
     // We re-read the configuration on every request for now
-    let cfg_str = match tokio::fs::read_to_string(&state.config_path).await {
+    let cfg_str = match crate::config::read_async(&state.config_path).await {
         Ok(s) => s,
         Err(err) => {
             return (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response();

--- a/tests/apply.rs
+++ b/tests/apply.rs
@@ -56,3 +56,15 @@ fn list_picks_first_match() {
         .success()
         .stdout(predicate::eq("https://two.example"));
 }
+
+#[test]
+fn missing_config_reports_path() {
+    let dir = assert_fs::TempDir::new().expect("temp dir");
+    let path = dir.path().join("config.yml");
+    let mut cmd = Command::cargo_bin("shortcut-catapult").expect("binary exists");
+    cmd.arg("--config").arg(&path).arg("apply").arg("Hello");
+    cmd.assert()
+        .failure()
+        .code(3)
+        .stderr(predicate::str::contains(path.to_string_lossy()));
+}


### PR DESCRIPTION
## Summary
- add helper functions to read config file with color-eyre context
- use helper from apply and daemon modes
- test missing config path is mentioned in error message

## Testing
- `cargo check --quiet`
- `cargo test --quiet`
- `cargo clippy --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68500cdf17d0832d99195a4060fd06c8